### PR TITLE
Bump the Z-index on the image annotation context menu.

### DIFF
--- a/css/islandora_cwrc_writer.image_annotation.css
+++ b/css/islandora_cwrc_writer.image_annotation.css
@@ -17,7 +17,7 @@
   font-weight: bold;
 }
 .context-menu-list {
-  z-index: 10 !important;
+  z-index: 65 !important;
 }
 .entitiesList .textimagelink .box {
   background-image: url('../images/cake.png');


### PR DESCRIPTION
Now it works with the stuff fullscreen! Wow!

Just for reference: We have to be higher than 60, due to: https://github.com/discoverygarden/emicdora/blob/3f2281688ffff36a28d83e95e040f94acfa1afe2/modules/tei_editor/css/tei_editor.cwrc.css#L23
