### PR TITLE
Revert "Comare against the annotations UUID not its bodys UUID."

### DIFF
--- a/js/islandora_cwrc_writer_image_annotation_dialog.js
+++ b/js/islandora_cwrc_writer_image_annotation_dialog.js
@@ -125,7 +125,7 @@
                   // parameters are required. Except entityID, entityLabel, it also
                   // generates identifiers for the annotation and it's content.
                   annotation = that.createAnnotation(values);
-                  uuid = jQuery(annotation).attr('about');
+                  uuid = jQuery(annotation).children('div[about]').attr('about');
                   Drupal.IslandoraImageAnnotation.on('processedAnnotation', function (event, annotation) {
                     if (annotation.id === uuid) {
                       data.writer.tagger.finalizeEntity('textimagelink', {


### PR DESCRIPTION
This reverts commit 2f975c6fcd029c5f64aa0d73bea30d9b405f499e.

Need to do this as of https://github.com/Islandora/islandora_image_annotation/commit/fe3c49cb7bec31357d2b4aa9383dccf3d6cd4505 we were constructing things as HTML to get around browser incompatibilities. Since we are making real XML again we have an extra div and it needs to get the children.
