### PR TITLE
Behave appropriately on "saveAndExit" in Firefox.

### DIFF
--- a/js/islandora_cwrc_writer.js
+++ b/js/islandora_cwrc_writer.js
@@ -170,14 +170,14 @@ function cwrcWriterInit($, Writer, Delegator) {
           dataType: 'json',
           data: {'doc':docText, 'schema':writer.schemaManager.schemas[writer.schemaManager.schemaId]['pid']},
           success: function(data, status, xhr) {
+              // XXX: Force the state to be clean directly after the "save"
+              // occurs.
+              writer.editor.isNotDirty = true;
+
               $.ajax({
                   url: Drupal.settings.basePath+'islandora/rest/v1/object/'+writer.currentDocId+'/lock',
                   type: 'DELETE',
                   success: function(data, status, xhr) {
-                      // Force the state to be clean, which has to be after the
-                      // window.location.hash is updated otherwise it may reset to the dirty
-                      // state.
-                      writer.editor.isNotDirty = true;
                       window.location = Drupal.settings.basePath+'islandora/object/'+writer.currentDocId
                   },
                   error: function() {

--- a/js/islandora_cwrc_writer.js
+++ b/js/islandora_cwrc_writer.js
@@ -174,11 +174,11 @@ function cwrcWriterInit($, Writer, Delegator) {
                   url: Drupal.settings.basePath+'islandora/rest/v1/object/'+writer.currentDocId+'/lock',
                   type: 'DELETE',
                   success: function(data, status, xhr) {
-                      window.location = Drupal.settings.basePath+'islandora/object/'+writer.currentDocId
                       // Force the state to be clean, which has to be after the
                       // window.location.hash is updated otherwise it may reset to the dirty
                       // state.
                       writer.editor.isNotDirty = true;
+                      window.location = Drupal.settings.basePath+'islandora/object/'+writer.currentDocId
                   },
                   error: function() {
                       writer.delegator.displayError(xhr, docId);


### PR DESCRIPTION
Setting `window.location` causes the redirect immediately in Firefox (so it would show the "Sure you want to do this?" business)