### PR TITLE
Add alias to support un-URL-encoded URLs.

### DIFF
--- a/includes/document.inc
+++ b/includes/document.inc
@@ -174,7 +174,7 @@ function islandora_cwrc_writer_style_document(AbstractDatastream $datastream, Ab
         // Attempt to add the two datastreams.
         foreach ($accessibles as $accessible) {
           $url = $schema_object[$accessible]->controlGroup === 'X' || $schema_object[$accessible]->controlGroup === 'M' ?
-            "$base_url/islandora/object/{$schema_object->id}/datastream/$accessible/view" :
+            islandora_cwrc_writer_get_absolute_url("islandora/object/{$schema_object->id}/datastream/$accessible/view") :
             $schema_object[$accessible]->url;
           if ($accessible == 'SCHEMA') {
             $cwrc = islandora_cwrc_writer_add_model_processing_instruction_to_string($cwrc, $url);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -157,6 +157,7 @@ function islandora_cwrc_writer_embedded_css() {
  *   so that the CWRC-Writer can function correctly.
  */
 function islandora_cwrc_writer_default_config() {
+  global $base_url;
   $cwrc_writer_path = libraries_get_path(ISLANDORA_CWRC_WRITER_LIB);
   return array(
     'project' => 'cwrc',
@@ -197,6 +198,9 @@ function islandora_cwrc_writer_default_config() {
         'aliases' => array(
           'http://cwrc.ca/schema/CWRC-TEIBasic.rng',
           'http://cwrc.ca/schemas/cwrc_tei_lite.rng',
+          // XXX: Generate an alias to match the old concatenated structure
+          // (without URL-encoding).
+          "$base_url/islandora/object/cwrc:teiSchema/datastream/SCHEMA/view",
         ),
         'schemaMappingsId' => ISLANDORA_CWRC_WRITER_SCHEMA_MAPPING_TEI,
       ),
@@ -205,7 +209,12 @@ function islandora_cwrc_writer_default_config() {
         'name' => 'CWRC Events Schema',
         'url' => url('islandora/object/cwrc:eventsSchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
         'cssUrl' => url('islandora/object/cwrc:eventsSchema/datastream/CSS/view', array('absolute' => TRUE)),
-        'aliases' => array('http://cwrc.ca/schemas/orlando_event.rng'),
+        'aliases' => array(
+          'http://cwrc.ca/schemas/orlando_event.rng',
+          // XXX: Generate an alias to match the old concatenated structure
+          // (without URL-encoding).
+          "$base_url/islandora/object/cwrc:eventsSchema/datastream/SCHEMA/view",
+        ),
         'schemaMappingsId' => ISLANDORA_CWRC_WRITER_SCHEMA_MAPPING_ORLANDO,
       ),
       'biography' => array(
@@ -213,7 +222,12 @@ function islandora_cwrc_writer_default_config() {
         'name' => 'CWRC Biography Schema',
         'url' => url('islandora/object/cwrc:biographySchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
         'cssUrl' => url('islandora/object/cwrc:biographySchema/datastream/CSS/view', array('absolute' => TRUE)),
-        'aliases' => array('http://cwrc.ca/schemas/orlando_biography.rng'),
+        'aliases' => array(
+          'http://cwrc.ca/schemas/orlando_biography.rng',
+          // XXX: Generate an alias to match the old concatenated structure
+          // (without URL-encoding).
+          "$base_url/islandora/object/cwrc:biographySchema/datastream/SCHEMA/view",
+        ),
         'schemaMappingsId' => ISLANDORA_CWRC_WRITER_SCHEMA_MAPPING_ORLANDO,
       ),
       'writing' => array(
@@ -221,7 +235,12 @@ function islandora_cwrc_writer_default_config() {
         'name' => 'CWRC Writing Schema',
         'url' => url('islandora/object/cwrc:writingSchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
         'cssUrl' => url('islandora/object/cwrc:writingSchema/datastream/CSS/view', array('absolute' => TRUE)),
-        'aliases' => array('http://cwrc.ca/schemas/orlando_writing.rng'),
+        'aliases' => array(
+          'http://cwrc.ca/schemas/orlando_writing.rng',
+          // XXX: Generate an alias to match the old concatenated structure
+          // (without URL-encoding).
+          "$base_url/islandora/object/cwrc:writingSchema/datastream/SCHEMA/view",
+        ),
         'schemaMappingsId' => ISLANDORA_CWRC_WRITER_SCHEMA_MAPPING_ORLANDO,
       ),
       'entry' => array(
@@ -229,7 +248,12 @@ function islandora_cwrc_writer_default_config() {
         'name' => 'CWRC Entry Schema',
         'url' => url('islandora/object/cwrc:entrySchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
         'cssUrl' => url('islandora/object/cwrc:entrySchema/datastream/CSS/view', array('absolute' => TRUE)),
-        'aliases' => array('http://cwrc.ca/schemas/cwrc_entry.rng'),
+        'aliases' => array(
+          'http://cwrc.ca/schemas/cwrc_entry.rng',
+          // XXX: Generate an alias to match the old concatenated structure
+          // (without URL-encoding).
+          "$base_url/islandora/object/cwrc:entrySchema/datastream/SCHEMA/view",
+        ),
         'schemaMappingsId' => ISLANDORA_CWRC_WRITER_SCHEMA_MAPPING_ENTRY,
       ),
     ),
@@ -953,6 +977,7 @@ function islandora_cwrc_writer_create_domdocument() {
  *   - schemaMappingsId: Indicates what mapping to use in the CWRC-Writer.
  */
 function islandora_cwrc_writer_get_schemas() {
+  global $base_url;
   $content_model = ISLANDORA_CWRC_WRITER_SCHEMA_CONTENT_MODEL;
   $cwrc_namespace = CWRC_RELS_EXT_URI;
   $query = <<<EOT
@@ -981,6 +1006,11 @@ EOT;
       'cssUrl' => url("islandora/object/{$pid}/datastream/CSS/view", array(
         'absolute' => TRUE,
       )),
+      'aliases' => array(
+        // XXX: Generate an alias to match the old concatenated structure
+        // (without URL-encoding).
+        "$base_url/islandora/object/$pid/datastream/SCHEMA/view",
+      ),
     );
     $schemas[$pid] = $schema;
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -162,9 +162,9 @@ function islandora_cwrc_writer_default_config() {
   return array(
     'project' => 'cwrc',
     // We need trailing slashes on the urls for CWRC to work.
-    'cwrcRootUrl' => url("$cwrc_writer_path/src/", array('absolute' => TRUE)),
+    'cwrcRootUrl' => file_create_url("$cwrc_writer_path/src/"),
     // The url in which we provide services for.
-    'baseUrl' => url('cwrc/', array('absolute' => TRUE)),
+    'baseUrl' => islandora_cwrc_writer_get_absolute_url('cwrc/'),
     // XML + RDF.
     'mode' => 0,
     'allowOverlap' => TRUE,
@@ -998,12 +998,8 @@ EOT;
       'pid' => $pid,
       'name' => $result['label']['value'],
       'schemaMappingsId' => $result['mapping']['value'],
-      'url' => url("islandora/object/{$pid}/datastream/SCHEMA/view", array(
-        'absolute' => TRUE,
-      )),
-      'cssUrl' => url("islandora/object/{$pid}/datastream/CSS/view", array(
-        'absolute' => TRUE,
-      )),
+      'url' => islandora_cwrc_writer_get_absolute_url("islandora/object/{$pid}/datastream/SCHEMA/view"),
+      'cssUrl' => islandora_cwrc_writer_get_absolute_url("islandora/object/{$pid}/datastream/CSS/view"),
       'aliases' => array(
         // XXX: Generate an alias to match the old concatenated structure
         // (without URL-encoding).

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -173,10 +173,10 @@ function islandora_cwrc_writer_default_config() {
     // run time.
     'documents' => array(),
     'cwrcDialogs' => array(
-      'cwrcApiUrl' => url(variable_get('islandora_cwrc_writer_cwrc_api_url', 'cwrc/api'), array('absolute' => TRUE)),
-      'geonameUrl' => url(variable_get('islandora_cwrc_writer_geo_names_url', 'geonames'), array('absolute' => TRUE)),
-      'googleGeocodeUrl' => url(variable_get('islandora_cwrc_writer_google_geocode_url', 'http://maps.googleapis.com/maps/api/geocode/xml'), array('absolute' => TRUE, 'external' => TRUE)),
-      'viafUrl' => url(variable_get('islandora_cwrc_writer_viaf_url', 'viaf'), array('absolute' => TRUE)),
+      'cwrcApiUrl' => islandora_cwrc_writer_get_absolute_url(variable_get('islandora_cwrc_writer_cwrc_api_url', 'cwrc/api')),
+      'geonameUrl' => islandora_cwrc_writer_get_absolute_url(variable_get('islandora_cwrc_writer_geo_names_url', 'geonames')),
+      'googleGeocodeUrl' => islandora_cwrc_writer_get_absolute_url(variable_get('islandora_cwrc_writer_google_geocode_url', 'http://maps.googleapis.com/maps/api/geocode/xml'), array('external' => TRUE)),
+      'viafUrl' => islandora_cwrc_writer_get_absolute_url(variable_get('islandora_cwrc_writer_viaf_url', 'viaf')),
       'schemas' => array(
         'person' => 'http://cwrc.ca/schemas/entities.rng',
         'organization' => 'http://cwrc.ca/schemas/entities.rng',
@@ -193,8 +193,8 @@ function islandora_cwrc_writer_default_config() {
       'tei' => array(
         'pid' => 'cwrc:teiSchema',
         'name' => 'CWRC Basic TEI Schema',
-        'url' => url('islandora/object/cwrc:teiSchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
-        'cssUrl' => url('islandora/object/cwrc:teiSchema/datastream/CSS/view', array('absolute' => TRUE)),
+        'url' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:teiSchema/datastream/SCHEMA/view'),
+        'cssUrl' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:teiSchema/datastream/CSS/view'),
         'aliases' => array(
           'http://cwrc.ca/schema/CWRC-TEIBasic.rng',
           'http://cwrc.ca/schemas/cwrc_tei_lite.rng',
@@ -207,8 +207,8 @@ function islandora_cwrc_writer_default_config() {
       'events' => array(
         'pid' => 'cwrc:eventsSchema',
         'name' => 'CWRC Events Schema',
-        'url' => url('islandora/object/cwrc:eventsSchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
-        'cssUrl' => url('islandora/object/cwrc:eventsSchema/datastream/CSS/view', array('absolute' => TRUE)),
+        'url' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:eventsSchema/datastream/SCHEMA/view'),
+        'cssUrl' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:eventsSchema/datastream/CSS/view'),
         'aliases' => array(
           'http://cwrc.ca/schemas/orlando_event.rng',
           // XXX: Generate an alias to match the old concatenated structure
@@ -220,8 +220,8 @@ function islandora_cwrc_writer_default_config() {
       'biography' => array(
         'pid' => 'cwrc:biographySchema',
         'name' => 'CWRC Biography Schema',
-        'url' => url('islandora/object/cwrc:biographySchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
-        'cssUrl' => url('islandora/object/cwrc:biographySchema/datastream/CSS/view', array('absolute' => TRUE)),
+        'url' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:biographySchema/datastream/SCHEMA/view'),
+        'cssUrl' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:biographySchema/datastream/CSS/view'),
         'aliases' => array(
           'http://cwrc.ca/schemas/orlando_biography.rng',
           // XXX: Generate an alias to match the old concatenated structure
@@ -233,8 +233,8 @@ function islandora_cwrc_writer_default_config() {
       'writing' => array(
         'pid' => 'cwrc:writingSchema',
         'name' => 'CWRC Writing Schema',
-        'url' => url('islandora/object/cwrc:writingSchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
-        'cssUrl' => url('islandora/object/cwrc:writingSchema/datastream/CSS/view', array('absolute' => TRUE)),
+        'url' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:writingSchema/datastream/SCHEMA/view'),
+        'cssUrl' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:writingSchema/datastream/CSS/view'),
         'aliases' => array(
           'http://cwrc.ca/schemas/orlando_writing.rng',
           // XXX: Generate an alias to match the old concatenated structure
@@ -246,8 +246,8 @@ function islandora_cwrc_writer_default_config() {
       'entry' => array(
         'pid' => 'cwrc:entrySchema',
         'name' => 'CWRC Entry Schema',
-        'url' => url('islandora/object/cwrc:entrySchema/datastream/SCHEMA/view', array('absolute' => TRUE)),
-        'cssUrl' => url('islandora/object/cwrc:entrySchema/datastream/CSS/view', array('absolute' => TRUE)),
+        'url' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:entrySchema/datastream/SCHEMA/view'),
+        'cssUrl' => islandora_cwrc_writer_get_absolute_url('islandora/object/cwrc:entrySchema/datastream/CSS/view'),
         'aliases' => array(
           'http://cwrc.ca/schemas/cwrc_entry.rng',
           // XXX: Generate an alias to match the old concatenated structure
@@ -493,9 +493,7 @@ EOT;
 function islandora_cwrc_writer_get_schema_url(AbstractObject $object) {
   $schema = islandora_cwrc_writer_get_document_schema_object($object);
   if ($schema) {
-    return url("islandora/object/{$schema->id}/datastream/SCHEMA/view", array(
-      'absolute' => TRUE,
-    ));
+    return islandora_cwrc_writer_get_absolute_url("islandora/object/{$schema->id}/datastream/SCHEMA/view");
   }
   return FALSE;
 }
@@ -1139,4 +1137,29 @@ function islandora_cwrc_writer_default_entity_collection($type) {
     return variable_get($variable, $default);
   }
   return FALSE;
+}
+
+/**
+ * Helper function to generate absolute URLs without language prefixes.
+ *
+ * @param string $path
+ *   The path, as accepted by url().
+ * @param array $options_in
+ *   Options, as accepted by url(). 'absolute' and 'language' will be
+ *   overridden.
+ *
+ * @return string
+ *   The absolute URL without language prefixes.
+ */
+function islandora_cwrc_writer_get_absolute_url($path, $options_in = array()) {
+  static $no_language = NULL;
+  if ($no_language === NULL) {
+    $no_language = new stdClass();
+    $no_language->language = LANGUAGE_NONE;
+  }
+
+  return url($path, array(
+    'absolute' => TRUE,
+    'language' => $no_language,
+  ) + $options_in);
 }

--- a/islandora_cwrc_writer.module
+++ b/islandora_cwrc_writer.module
@@ -184,7 +184,7 @@ function islandora_cwrc_writer_theme($existing, $type, $theme, $path) {
     'islandora_cwrc_writer_embedded' => array(
       'file' => 'theme/theme.inc',
       'variables' => array(
-        'src' => url('cwrc/editor'),
+        'src' => islandora_cwrc_writer_get_absolute_url('cwrc/editor'),
         'width' => '100%',
         'height' => '800px',
       ),


### PR DESCRIPTION
(colons in the path need not be encoded)

... due to [comparison of URLs as strings](https://github.com/discoverygarden/CWRC-Writer/blob/development/src/js/converter.js#L543) (the first condition on the third line, below):
```js
                $.each(w.schemaManager.schemas, function(id, schema) {
                    var aliases = schema.aliases || [];
                    if (schemaUrl == schema.url || $.inArray(schemaUrl, aliases) !== -1) {
                        schemaId = id;
                        cssFilename = null;
                        return false;
                    }
```
... so we make the second condition pass.