### PR TITLE
Force scripts to be loaded after everything else so that requirejs doesn't interfere

### DIFF
--- a/islandora_cwrc_writer.module
+++ b/islandora_cwrc_writer.module
@@ -238,6 +238,8 @@ function islandora_cwrc_writer_libraries_info() {
   // display.
   $default_js_properties = $default_css_properties = array(
     ISLANDORA_CWRC_WRITER_RESOURCE_FLAG => TRUE,
+    'weight' => 500,      // Load absolutely last
+    'group' => JS_THEME,  // Load after our theme scripts so require.js doesn't interfere
   );
   return array(
     'CWRC-Writer' => array(


### PR DESCRIPTION
This change will make it so that the JavaScript for CWRC-Writer loads last (assuming nothing else attempts to do the same) so that require.js does not interfere with other libraries. This only impacts the weight of the JS and not the CSS.