### PR TITLE
Use module machine name as key in hook_requirements().

### DIFF
--- a/islandora_cwrc_writer.install
+++ b/islandora_cwrc_writer.install
@@ -13,21 +13,14 @@ function islandora_cwrc_writer_requirements($phase) {
   $requirements = array(
     'islandora_cwrc_writer' => array('title' => $t('CWRC-Writer Library')),
   );
-  $library = array(
-    'library path' => libraries_get_path('CWRC-Writer'),
-  );
-  $options = array(
-    'file' => 'src/editor_dev.htm',
-    'pattern' => '/CWRC-Writer v([0-9.]+)/',
-    'lines' => 200,
-  );
-  if (file_exists($library['library path'])) {
+  $library = libraries_detect('CWRC-Writer');
+  if ($library['installed']) {
     $requirements['islandora_cwrc_writer']['severity'] = REQUIREMENT_OK;
-    $requirements['islandora_cwrc_writer']['value'] = libraries_get_version($library, $options);
+    $requirements['islandora_cwrc_writer']['value'] = $library['version'];
   }
   else {
     $requirements['islandora_cwrc_writer']['severity'] = REQUIREMENT_ERROR;
-    $requirements['islandora_cwrc_writer']['value'] = $t('Not found');
+    $requirements['islandora_cwrc_writer']['value'] = $library['error'];
     $requirements['islandora_cwrc_writer']['description'] = $t('The <a href="@cwrc">CWRC-Writer Library</a> is missing. <a href="@download">Download</a> and extract it into the <code>@directory</code> directory. Rename the extracted folder to <code>@library-folder</code>.', array(
         '@cwrc' => 'https://github.com/cwrc/CWRC-Writer',
         '@download' => 'https://github.com/cwrc/CWRC-Writer/archive/development.zip',

--- a/islandora_cwrc_writer.install
+++ b/islandora_cwrc_writer.install
@@ -11,7 +11,7 @@
 function islandora_cwrc_writer_requirements($phase) {
   $t = get_t();
   $requirements = array(
-    'cwrc' => array('title' => $t('CWRC-Writer Library')),
+    'islandora_cwrc_writer' => array('title' => $t('CWRC-Writer Library')),
   );
   $library = array(
     'library path' => libraries_get_path('CWRC-Writer'),
@@ -22,13 +22,13 @@ function islandora_cwrc_writer_requirements($phase) {
     'lines' => 200,
   );
   if (file_exists($library['library path'])) {
-    $requirements['cwrc']['severity'] = REQUIREMENT_OK;
-    $requirements['cwrc']['value'] = libraries_get_version($library, $options);
+    $requirements['islandora_cwrc_writer']['severity'] = REQUIREMENT_OK;
+    $requirements['islandora_cwrc_writer']['value'] = libraries_get_version($library, $options);
   }
   else {
-    $requirements['cwrc']['severity'] = REQUIREMENT_ERROR;
-    $requirements['cwrc']['value'] = $t('Not found');
-    $requirements['cwrc']['description'] = $t('The <a href="@cwrc">CWRC-Writer Library</a> is missing. <a href="@download">Download</a> and extract it into the <code>@directory</code> directory. Rename the extracted folder to <code>@library-folder</code>.', array(
+    $requirements['islandora_cwrc_writer']['severity'] = REQUIREMENT_ERROR;
+    $requirements['islandora_cwrc_writer']['value'] = $t('Not found');
+    $requirements['islandora_cwrc_writer']['description'] = $t('The <a href="@cwrc">CWRC-Writer Library</a> is missing. <a href="@download">Download</a> and extract it into the <code>@directory</code> directory. Rename the extracted folder to <code>@library-folder</code>.', array(
         '@cwrc' => 'https://github.com/cwrc/CWRC-Writer',
         '@download' => 'https://github.com/cwrc/CWRC-Writer/archive/development.zip',
         '@directory' => 'sites/all/libraries',


### PR DESCRIPTION
# Problem / motivation

> As a site administrator, I want separate status report items for `islandora_cwrc_basexdb` and `islandora_cwrc_writer` so that I can tell whether each module is working independently of the other.
> As a site administrator, I don't want to see unnecessary "Array to string conversion errors" when I go to the status report page or in my log messages, so that I can spend less time administrating the site and important messages do not get lost in the noise.

Previously, in `hook_requirements()`, this module prefixed all of its status information under the key `cwrc`, which conflicted with the `islandora_cwrc_basexdb` module (see cwrc/islandora_cwrc_basexdb#1 for a change to that module), and also caused "Array to string conversion" errors on the site's status report as two unrelated status lines were mashed together.

# Proposed resolution

Prefix all of this module's status information under a key with the same machine name as the module.

# Remaining tasks

- [ ] Code review
- [ ] Commit

# User interface changes

The status report lines for `islandora_cwrc_basexdb` and `islandora_cwrc_writer` are now separate.

# API changes

Anything wishing to override the status report item for this module must now override the requirement with key `islandora_cwrc_writer`.

# Data model changes

None.